### PR TITLE
Fix packet background min height

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -147,3 +147,9 @@ blockquote {
         min-height: 500px;
     }
 }
+
+@media (min-width: 1530px) {
+    blockquote {
+        min-height: 170px;
+    }
+}


### PR DESCRIPTION
On bigger screens packet bg is being trimmed:

![](http://cl.ly/0I084235060B/Screenshot%202016-03-30%2013.04.19.png)

This PR will increase `min-height` for them.