### PR TITLE
Fix tiny typo in the FAQ

### DIFF
--- a/templates/messaging/faq.html
+++ b/templates/messaging/faq.html
@@ -65,7 +65,7 @@
     <p>
         If both the sender and the recipient of the message agree to publish the message on the website,
         the message will be displayed in the <a href="{% url 'messaging:archive' %}">Happiness Archive</a>.
-        We encourage you to share your messages with the communit,
+        We encourage you to share your messages with the community,
         but the choice is yours and you are not obligated to choose this option if you do not feel comfortable with it.
         You can also choose to publish the message but keep the sender and recipient names private.
     </p>


### PR DESCRIPTION
I hope you don't mind the single character pull request - just reading through the FAQ and spotted a typo (if you'd rather fix this yourself, feel free :)).

Love the idea by the way - what a wonderful thing to have built!