### PR TITLE
Add a copy of the message to be sent to the sender

### DIFF
--- a/templates/messaging/sender_confirmation_mail.html
+++ b/templates/messaging/sender_confirmation_mail.html
@@ -6,6 +6,15 @@
 
 <p>
     You just requested to send a Happiness Packet to {{ message.recipient_name }}.
+</p>
+
+<p>
+    Your message reads: 
+</p>
+
+<p><em>{{ message.message|linebreaksbr }}</em></p>
+
+<p>
     To confirm and send your message, click or copy this link to a web browser:
 </p>
 

--- a/templates/messaging/sender_confirmation_mail.txt
+++ b/templates/messaging/sender_confirmation_mail.txt
@@ -1,6 +1,13 @@
 Hello {{ message.sender_name }}!
 
 You just requested to send a Happiness Packet to {{ message.recipient_name }}.
+
+Your message reads: 
+
+---------------------
+{{ message.message }}
+---------------------
+
 To confirm and send your message, click or copy this link to a web browser:
 {{ protocol }}://{{ domain }}{% url 'messaging:sender_confirm' identifier=message.identifier token=message.sender_email_token %}
 


### PR DESCRIPTION
Given there's no account logic, the only way history is traceable is via the emails happinesspackets.io has sent me in the past

As a recipient, I can see the message contents in my email. This is good 💌 

As a sender, I can only see the recipient's name, not the message, in my email. I have no way to confirm what I send before clicking 'Send my happiness packet', and I have no historical record of what happiness packets I've sent in the past (only to who they have been sent)

p.s. I'm not a django dev, I took a rough guess as to what the variable containing the message contents is based on existing templates. 