### PR TITLE
Update max width of email body to 600px to improve readability

### DIFF
--- a/templates/base_email.html
+++ b/templates/base_email.html
@@ -12,7 +12,7 @@
     <div style="text-align: center;padding: 20px;">
         <img src="cid:logo.png@happinesspackets.io" alt="Open-source Happiness Packets" style="max-width: 400px; padding: 30px">
     </div>
-    <div style="margin: auto;background-color: white;max-width: 400px;padding: 30px">
+    <div style="margin: auto;background-color: white;max-width: 600px;padding: 30px">
         {% block content %}{% endblock %}
         <footer style="line-height: 1.2em;"><small>
             <hr>


### PR DESCRIPTION
I think the 400px max-width setting is a little bit too small. It looks great on mobile, but on full desktop experience, the reading area is tiny. This PR updates it to 600px.

Screenshot of what 400px looked like for me:

![screen shot 2016-07-21 at 11 23 37](https://cloud.githubusercontent.com/assets/527795/17028463/b6652c5a-4f35-11e6-8244-89c05e074b14.png)
